### PR TITLE
feat: ephemeral PR preview environments on Fly.io via Tailscale

### DIFF
--- a/.github/workflows/pr-image.yaml
+++ b/.github/workflows/pr-image.yaml
@@ -1,0 +1,47 @@
+name: PR Image
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Build & push prod image for PR
+    runs-on: ubuntu-latest
+    # Owner-only: skip PRs opened by anyone else (incl. Dependabot, forks).
+    if: github.event.pull_request.user.login == github.event.repository.owner.login
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=pr-${{ github.event.pull_request.number }}
+            type=raw,value=sha-${{ github.event.pull_request.head.sha }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/pr-image.yaml
+++ b/.github/workflows/pr-image.yaml
@@ -18,25 +18,25 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=pr-${{ github.event.pull_request.number }}
             type=raw,value=sha-${{ github.event.pull_request.head.sha }}
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true

--- a/.github/workflows/preview-image-check.yaml
+++ b/.github/workflows/preview-image-check.yaml
@@ -1,0 +1,40 @@
+name: Preview Image Check
+
+on:
+  pull_request:
+    paths:
+      - 'preview.Dockerfile'
+      - 'scripts/preview-entrypoint.sh'
+      - 'fly.preview.toml'
+      - 'Dockerfile'
+      - '.github/workflows/preview-image-check.yaml'
+
+jobs:
+  build-check:
+    name: Build preview image (no deploy)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build prod image locally as :pr-check
+        run: |
+          docker build \
+            -f Dockerfile \
+            -t ghcr.io/stevensdavid/prodzilla:pr-check \
+            .
+
+      - name: Build preview image FROM :pr-check
+        run: |
+          docker build \
+            -f preview.Dockerfile \
+            --build-arg PR_NUMBER=check \
+            -t prodzilla-preview:check \
+            .
+
+      - name: Verify entrypoint is executable
+        run: |
+          docker run --rm --entrypoint /bin/sh prodzilla-preview:check \
+            -c 'test -x /usr/local/bin/preview-entrypoint.sh \
+                && command -v tailscaled >/dev/null \
+                && command -v tailscale >/dev/null \
+                && test -x /bin/prodzilla'

--- a/.github/workflows/preview-image-check.yaml
+++ b/.github/workflows/preview-image-check.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Build preview image (no deploy)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build prod image locally as :pr-check
         run: |

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -45,7 +45,7 @@ jobs:
       app_name: ${{ steps.compute.outputs.app_name }}
     steps:
       - id: compute
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const event = context.eventName;
@@ -110,12 +110,12 @@ jobs:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ needs.resolve.outputs.head_sha }}
 
       - name: Apply preview label
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.issues.addLabels({
@@ -200,7 +200,7 @@ jobs:
           fi
           echo "suffix=$SUFFIX" >> "$GITHUB_OUTPUT"
 
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master @ 2026-05-03
 
       - name: Create Fly app if missing
         env:
@@ -222,7 +222,7 @@ jobs:
 
       - name: Create GitHub Deployment (in_progress)
         id: deployment
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const dep = await github.rest.repos.createDeployment({
@@ -259,7 +259,7 @@ jobs:
 
       - name: Find existing sticky comment
         id: find_comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
         with:
           issue-number: ${{ env.PR_NUMBER }}
           comment-author: 'github-actions[bot]'
@@ -267,7 +267,7 @@ jobs:
 
       - name: Mark Deployment success
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.repos.createDeploymentStatus({
@@ -283,7 +283,7 @@ jobs:
 
       - name: Upsert sticky comment (success)
         if: success()
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         with:
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           issue-number: ${{ env.PR_NUMBER }}
@@ -300,7 +300,7 @@ jobs:
 
       - name: Mark Deployment failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.repos.createDeploymentStatus({
@@ -313,7 +313,7 @@ jobs:
 
       - name: Upsert sticky comment (failure)
         if: failure()
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         with:
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           issue-number: ${{ env.PR_NUMBER }}
@@ -335,7 +335,7 @@ jobs:
       APP_NAME: ${{ needs.resolve.outputs.app_name }}
       PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
     steps:
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master @ 2026-05-03
 
       - name: Mint Tailscale OAuth token
         id: ts
@@ -372,7 +372,7 @@ jobs:
         run: flyctl apps destroy "$APP_NAME" --yes 2>/dev/null || true
 
       - name: Delete GHCR tags for this PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const owner = context.repo.owner;
@@ -404,7 +404,7 @@ jobs:
 
       - name: Remove preview label
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             try {
@@ -420,7 +420,7 @@ jobs:
 
       - name: Mark Deployments inactive
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const env = `preview-pr-${process.env.PR_NUMBER}`;
@@ -442,7 +442,7 @@ jobs:
       - name: Find existing sticky comment
         if: always()
         id: find_comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
         with:
           issue-number: ${{ env.PR_NUMBER }}
           comment-author: 'github-actions[bot]'
@@ -450,7 +450,7 @@ jobs:
 
       - name: Update sticky comment
         if: always()
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         with:
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           issue-number: ${{ env.PR_NUMBER }}

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -4,7 +4,10 @@ on:
   issue_comment:
     types: [created]
   pull_request:
-    types: [synchronize, closed]
+    types: [closed]
+  workflow_run:
+    workflows: ["PR Image"]
+    types: [completed]
 
 permissions:
   contents: read
@@ -12,27 +15,29 @@ permissions:
   issues: write
   pull-requests: write
   deployments: write
+  actions: read
 
 concurrency:
-  group: preview-pr-${{ github.event.issue.number || github.event.pull_request.number }}
+  group: preview-pr-${{ github.event.issue.number || github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number }}
   cancel-in-progress: false
 
 jobs:
   resolve:
     name: Resolve dispatch
     runs-on: ubuntu-latest
+    # Coarse event-shape filter; fine-grained checks (label presence,
+    # workflow_run conclusion) live in the script and may set action=''.
     if: |
       (github.event_name == 'issue_comment'
         && github.event.issue.pull_request != null
         && github.event.comment.user.login == github.event.repository.owner.login
         && (startsWith(github.event.comment.body, '/preview') || startsWith(github.event.comment.body, '/teardown')))
       || (github.event_name == 'pull_request'
-        && github.event.action == 'synchronize'
-        && github.event.pull_request.user.login == github.event.repository.owner.login
-        && contains(github.event.pull_request.labels.*.name, 'preview'))
-      || (github.event_name == 'pull_request'
         && github.event.action == 'closed'
         && contains(github.event.pull_request.labels.*.name, 'preview'))
+      || (github.event_name == 'workflow_run'
+        && github.event.workflow_run.conclusion == 'success'
+        && github.event.workflow_run.event == 'pull_request')
     outputs:
       action: ${{ steps.compute.outputs.action }}
       pr_number: ${{ steps.compute.outputs.pr_number }}
@@ -44,7 +49,7 @@ jobs:
         with:
           script: |
             const event = context.eventName;
-            let action, prNumber, headSha;
+            let action = '', prNumber, headSha;
 
             if (event === 'issue_comment') {
               const body = context.payload.comment.body.trim();
@@ -58,15 +63,38 @@ jobs:
               });
               headSha = pr.data.head.sha;
             } else if (event === 'pull_request') {
+              // Only `closed` reaches this branch (filtered by `if:` above).
               prNumber = context.payload.pull_request.number;
               headSha = context.payload.pull_request.head.sha;
-              action = context.payload.action === 'closed' ? 'teardown' : 'preview';
+              action = 'teardown';
+            } else if (event === 'workflow_run') {
+              // pr-image.yaml succeeded — auto-redeploy if the PR is labeled.
+              const wr = context.payload.workflow_run;
+              headSha = wr.head_sha;
+              const prs = wr.pull_requests || [];
+              if (prs.length === 0) {
+                core.info('workflow_run had no associated PRs; skipping');
+              } else {
+                prNumber = prs[0].number;
+                const pr = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                });
+                const hasLabel = pr.data.labels.some(l => l.name === 'preview');
+                const ownerOpened = pr.data.user.login === context.repo.owner;
+                if (hasLabel && ownerOpened) {
+                  action = 'preview';
+                } else {
+                  core.info(`PR #${prNumber} not eligible (label=${hasLabel}, owner=${ownerOpened})`);
+                }
+              }
             }
 
-            const appName = `stevensdavid-prodzilla-pr-${prNumber}`;
+            const appName = prNumber ? `stevensdavid-prodzilla-pr-${prNumber}` : '';
             core.setOutput('action', action);
-            core.setOutput('pr_number', prNumber);
-            core.setOutput('head_sha', headSha);
+            core.setOutput('pr_number', prNumber || '');
+            core.setOutput('head_sha', headSha || '');
             core.setOutput('app_name', appName);
 
   preview:

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,0 +1,434 @@
+name: Preview
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [synchronize, closed]
+
+permissions:
+  contents: read
+  packages: write
+  issues: write
+  pull-requests: write
+  deployments: write
+
+concurrency:
+  group: preview-pr-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve dispatch
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'issue_comment'
+        && github.event.issue.pull_request != null
+        && github.event.comment.user.login == github.event.repository.owner.login
+        && (startsWith(github.event.comment.body, '/preview') || startsWith(github.event.comment.body, '/teardown')))
+      || (github.event_name == 'pull_request'
+        && github.event.action == 'synchronize'
+        && github.event.pull_request.user.login == github.event.repository.owner.login
+        && contains(github.event.pull_request.labels.*.name, 'preview'))
+      || (github.event_name == 'pull_request'
+        && github.event.action == 'closed'
+        && contains(github.event.pull_request.labels.*.name, 'preview'))
+    outputs:
+      action: ${{ steps.compute.outputs.action }}
+      pr_number: ${{ steps.compute.outputs.pr_number }}
+      head_sha: ${{ steps.compute.outputs.head_sha }}
+      app_name: ${{ steps.compute.outputs.app_name }}
+    steps:
+      - id: compute
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const event = context.eventName;
+            let action, prNumber, headSha;
+
+            if (event === 'issue_comment') {
+              const body = context.payload.comment.body.trim();
+              if (body.startsWith('/preview')) action = 'preview';
+              else if (body.startsWith('/teardown')) action = 'teardown';
+              prNumber = context.payload.issue.number;
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              });
+              headSha = pr.data.head.sha;
+            } else if (event === 'pull_request') {
+              prNumber = context.payload.pull_request.number;
+              headSha = context.payload.pull_request.head.sha;
+              action = context.payload.action === 'closed' ? 'teardown' : 'preview';
+            }
+
+            const appName = `stevensdavid-prodzilla-pr-${prNumber}`;
+            core.setOutput('action', action);
+            core.setOutput('pr_number', prNumber);
+            core.setOutput('head_sha', headSha);
+            core.setOutput('app_name', appName);
+
+  preview:
+    name: Deploy preview
+    needs: resolve
+    if: needs.resolve.outputs.action == 'preview'
+    runs-on: ubuntu-latest
+    environment: pr-preview
+    env:
+      APP_NAME: ${{ needs.resolve.outputs.app_name }}
+      PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+      HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.head_sha }}
+
+      - name: Apply preview label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: parseInt(process.env.PR_NUMBER, 10),
+              labels: ['preview'],
+            });
+
+      - name: Wait for prod PR image to be available on GHCR
+        run: |
+          set -euo pipefail
+          IMAGE="${REGISTRY}/${IMAGE_NAME}:sha-${HEAD_SHA}"
+          for i in $(seq 1 60); do
+            if docker manifest inspect "$IMAGE" >/dev/null 2>&1; then
+              echo "Image $IMAGE is ready"
+              exit 0
+            fi
+            echo "Waiting for $IMAGE (attempt $i/60)..."
+            sleep 10
+          done
+          echo "Image $IMAGE was not pushed within 10 minutes" >&2
+          exit 1
+
+      - name: Mint Tailscale OAuth token and auth key
+        id: ts
+        env:
+          TS_OAUTH_CLIENT_ID: ${{ vars.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_CLIENT_SECRET: ${{ secrets.TS_OAUTH_CLIENT_SECRET }}
+        run: |
+          set -euo pipefail
+          TOKEN=$(curl -fsSL \
+            -u "${TS_OAUTH_CLIENT_ID}:${TS_OAUTH_CLIENT_SECRET}" \
+            -d "grant_type=client_credentials" \
+            https://api.tailscale.com/api/v2/oauth/token | jq -r .access_token)
+          echo "::add-mask::$TOKEN"
+
+          AUTHKEY=$(curl -fsSL -X POST \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{"capabilities":{"devices":{"create":{"reusable":false,"ephemeral":true,"preauthorized":true,"tags":["tag:prodzilla-preview"]}}},"expirySeconds":3600}' \
+            https://api.tailscale.com/api/v2/tailnet/-/keys | jq -r .key)
+          echo "::add-mask::$AUTHKEY"
+
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+          echo "authkey=$AUTHKEY" >> "$GITHUB_OUTPUT"
+
+      - name: Delete stale Tailscale node by hostname
+        env:
+          TS_TOKEN: ${{ steps.ts.outputs.token }}
+        run: |
+          set -euo pipefail
+          DEVICES=$(curl -fsSL -H "Authorization: Bearer $TS_TOKEN" \
+            https://api.tailscale.com/api/v2/tailnet/-/devices)
+          ID=$(echo "$DEVICES" | jq -r --arg n "$APP_NAME" \
+            '.devices[] | select(.hostname == $n) | .id' | head -n1)
+          if [ -n "$ID" ]; then
+            echo "Deleting stale Tailscale node $ID ($APP_NAME)"
+            STATUS=$(curl -sS -o /dev/null -w "%{http_code}" -X DELETE \
+              -H "Authorization: Bearer $TS_TOKEN" \
+              "https://api.tailscale.com/api/v2/device/$ID")
+            case "$STATUS" in
+              200|204|404) ;;
+              *) echo "Failed to delete node $ID (status $STATUS)" >&2; exit 1 ;;
+            esac
+          else
+            echo "No stale node for hostname $APP_NAME"
+          fi
+
+      - name: Resolve tailnet DNS suffix
+        id: tailnet
+        env:
+          TS_TOKEN: ${{ steps.ts.outputs.token }}
+        run: |
+          set -euo pipefail
+          SUFFIX=$(curl -fsSL -H "Authorization: Bearer $TS_TOKEN" \
+            https://api.tailscale.com/api/v2/tailnet/-/devices | \
+            jq -r '.devices[0].name' | sed -E 's/^[^.]+\.//')
+          if [ -z "$SUFFIX" ] || [ "$SUFFIX" = "null" ]; then
+            echo "Could not resolve tailnet DNS suffix" >&2
+            exit 1
+          fi
+          echo "suffix=$SUFFIX" >> "$GITHUB_OUTPUT"
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Create Fly app if missing
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          if ! flyctl apps list --json | jq -e --arg n "$APP_NAME" \
+              '.[] | select(.Name == $n)' >/dev/null; then
+            flyctl apps create --name "$APP_NAME" --org personal
+          else
+            echo "Fly app $APP_NAME already exists"
+          fi
+
+      - name: Stage TS_AUTHKEY on Fly app
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          TS_AUTHKEY: ${{ steps.ts.outputs.authkey }}
+        run: flyctl secrets set TS_AUTHKEY="$TS_AUTHKEY" --app "$APP_NAME" --stage
+
+      - name: Create GitHub Deployment (in_progress)
+        id: deployment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const dep = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: process.env.HEAD_SHA,
+              environment: `preview-pr-${process.env.PR_NUMBER}`,
+              auto_merge: false,
+              required_contexts: [],
+              transient_environment: true,
+              production_environment: false,
+              description: `Preview for PR #${process.env.PR_NUMBER}`,
+            });
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: dep.data.id,
+              state: 'in_progress',
+            });
+            core.setOutput('id', dep.data.id);
+
+      - name: Deploy to Fly
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          flyctl deploy \
+            --app "$APP_NAME" \
+            --config fly.preview.toml \
+            --build-arg PR_NUMBER="$PR_NUMBER" \
+            --image-label "sha-$HEAD_SHA" \
+            --remote-only \
+            --strategy immediate \
+            --ha=false
+
+      - name: Find existing sticky comment
+        id: find_comment
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ env.PR_NUMBER }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- preview-bot -->'
+
+      - name: Mark Deployment success
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: ${{ steps.deployment.outputs.id }},
+              state: 'success',
+              environment_url: `https://${process.env.APP_NAME}.${process.env.TAILNET_SUFFIX}`,
+              log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+        env:
+          TAILNET_SUFFIX: ${{ steps.tailnet.outputs.suffix }}
+
+      - name: Upsert sticky comment (success)
+        if: success()
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          issue-number: ${{ env.PR_NUMBER }}
+          edit-mode: replace
+          body: |
+            <!-- preview-bot -->
+            🚀 **Preview deployed**
+
+            URL: https://${{ env.APP_NAME }}.${{ steps.tailnet.outputs.suffix }}
+            Commit: `${{ env.HEAD_SHA }}`
+
+            Connect Tailscale on your phone, then open the URL.
+            Use `/teardown` or close the PR to dispose of this environment.
+
+      - name: Mark Deployment failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: ${{ steps.deployment.outputs.id || 0 }},
+              state: 'failure',
+              log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+
+      - name: Upsert sticky comment (failure)
+        if: failure()
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          issue-number: ${{ env.PR_NUMBER }}
+          edit-mode: replace
+          body: |
+            <!-- preview-bot -->
+            ❌ **Preview deploy failed**
+
+            Commit: `${{ env.HEAD_SHA }}`
+            See run logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+  teardown:
+    name: Teardown preview
+    needs: resolve
+    if: needs.resolve.outputs.action == 'teardown'
+    runs-on: ubuntu-latest
+    environment: pr-preview
+    env:
+      APP_NAME: ${{ needs.resolve.outputs.app_name }}
+      PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+    steps:
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Mint Tailscale OAuth token
+        id: ts
+        env:
+          TS_OAUTH_CLIENT_ID: ${{ vars.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_CLIENT_SECRET: ${{ secrets.TS_OAUTH_CLIENT_SECRET }}
+        run: |
+          set -euo pipefail
+          TOKEN=$(curl -fsSL \
+            -u "${TS_OAUTH_CLIENT_ID}:${TS_OAUTH_CLIENT_SECRET}" \
+            -d "grant_type=client_credentials" \
+            https://api.tailscale.com/api/v2/oauth/token | jq -r .access_token)
+          echo "::add-mask::$TOKEN"
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+
+      - name: Delete Tailscale node
+        env:
+          TS_TOKEN: ${{ steps.ts.outputs.token }}
+        run: |
+          set -euo pipefail
+          DEVICES=$(curl -fsSL -H "Authorization: Bearer $TS_TOKEN" \
+            https://api.tailscale.com/api/v2/tailnet/-/devices)
+          ID=$(echo "$DEVICES" | jq -r --arg n "$APP_NAME" \
+            '.devices[] | select(.hostname == $n) | .id' | head -n1)
+          if [ -n "$ID" ]; then
+            curl -sS -o /dev/null -X DELETE \
+              -H "Authorization: Bearer $TS_TOKEN" \
+              "https://api.tailscale.com/api/v2/device/$ID" || true
+          fi
+
+      - name: Destroy Fly app
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: flyctl apps destroy "$APP_NAME" --yes 2>/dev/null || true
+
+      - name: Delete GHCR tags for this PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const pkg = context.repo.repo;
+            const prTag = `pr-${process.env.PR_NUMBER}`;
+
+            const versions = await github.paginate(
+              github.rest.packages.getAllPackageVersionsForPackageOwnedByUser,
+              {
+                package_type: 'container',
+                package_name: pkg,
+                username: owner,
+                per_page: 100,
+              },
+            );
+
+            for (const v of versions) {
+              const tags = (v.metadata?.container?.tags) || [];
+              if (tags.includes(prTag)) {
+                console.log(`Deleting version ${v.id} (tags: ${tags.join(', ')})`);
+                await github.rest.packages.deletePackageVersionForUser({
+                  package_type: 'container',
+                  package_name: pkg,
+                  username: owner,
+                  package_version_id: v.id,
+                });
+              }
+            }
+
+      - name: Remove preview label
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: parseInt(process.env.PR_NUMBER, 10),
+                name: 'preview',
+              });
+            } catch (e) {
+              if (e.status !== 404) throw e;
+            }
+
+      - name: Mark Deployments inactive
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const env = `preview-pr-${process.env.PR_NUMBER}`;
+            const deps = await github.paginate(github.rest.repos.listDeployments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              environment: env,
+              per_page: 100,
+            });
+            for (const d of deps) {
+              await github.rest.repos.createDeploymentStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: d.id,
+                state: 'inactive',
+              });
+            }
+
+      - name: Find existing sticky comment
+        if: always()
+        id: find_comment
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ env.PR_NUMBER }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- preview-bot -->'
+
+      - name: Update sticky comment
+        if: always()
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          issue-number: ${{ env.PR_NUMBER }}
+          edit-mode: replace
+          body: |
+            <!-- preview-bot -->
+            🧹 **Preview torn down**
+
+            The Fly app for this PR has been destroyed.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG RUST_VERSION=1.78
+ARG RUST_VERSION=1.85
 
 # Build frontend
 FROM node:20-slim AS frontend-build

--- a/fly.preview.toml
+++ b/fly.preview.toml
@@ -1,0 +1,17 @@
+# Per-PR preview environment template.
+# `app` is set per-PR by the preview workflow via `flyctl deploy --app ...`.
+# No [[services]] block: no public IP, no Fly proxy ingress.
+# All access is via the Tailscale sidecar inside the machine.
+
+primary_region = "arn"
+
+[build]
+  dockerfile = "preview.Dockerfile"
+
+[env]
+  RUST_LOG = "info"
+
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 1
+  memory_mb = 256

--- a/preview.Dockerfile
+++ b/preview.Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1
+#
+# Layered on top of the per-PR prod image. PR_NUMBER is supplied by the
+# preview deploy workflow and selects the GHCR tag built by pr-image.yaml.
+ARG PR_NUMBER
+FROM ghcr.io/stevensdavid/prodzilla:pr-${PR_NUMBER}
+
+USER root
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        gnupg \
+        ca-certificates \
+    && curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.noarmor.gpg \
+        -o /usr/share/keyrings/tailscale-archive-keyring.gpg \
+    && curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.tailscale-keyring.list \
+        -o /etc/apt/sources.list.d/tailscale.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends tailscale \
+    && apt-get purge -y curl gnupg \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY scripts/preview-entrypoint.sh /usr/local/bin/preview-entrypoint.sh
+RUN chmod +x /usr/local/bin/preview-entrypoint.sh
+
+USER appuser
+
+ENTRYPOINT ["/usr/local/bin/preview-entrypoint.sh"]

--- a/scripts/preview-entrypoint.sh
+++ b/scripts/preview-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -eu
+
+SOCK=/tmp/tailscaled.sock
+
+tailscaled \
+    --tun=userspace-networking \
+    --state=mem: \
+    --socket="$SOCK" &
+
+i=0
+until tailscale --socket="$SOCK" status >/dev/null 2>&1; do
+    i=$((i + 1))
+    if [ $i -gt 50 ]; then
+        echo "tailscaled did not become ready within 10s" >&2
+        exit 1
+    fi
+    sleep 0.2
+done
+
+tailscale --socket="$SOCK" up \
+    --auth-key="$TS_AUTHKEY" \
+    --hostname="$FLY_APP_NAME" \
+    --advertise-tags=tag:prodzilla-preview \
+    --accept-dns=false
+
+tailscale --socket="$SOCK" serve --bg --https=443 http://localhost:3000
+
+exec /bin/prodzilla


### PR DESCRIPTION
## Summary

- Adds opt-in per-PR preview deployments on Fly.io, reachable only over the maintainer's personal Tailscale tailnet (no public IP, HTTPS via Tailscale Serve).
- Comment `/preview` on a PR to deploy, push to the PR to auto-redeploy, comment `/teardown` or close the PR to dispose. Owner-only.
- Stable per-PR URL across redeploys: `https://stevensdavid-prodzilla-pr-N.<tailnet>.ts.net`.

## Architecture

| File | Purpose |
| --- | --- |
| `preview.Dockerfile` | `FROM ghcr.io/stevensdavid/prodzilla:pr-${PR_NUMBER}` + Tailscale + entrypoint. |
| `scripts/preview-entrypoint.sh` | Starts `tailscaled` in userspace-networking mode, brings up the node tagged `tag:prodzilla-preview`, runs `tailscale serve --https=443 http://localhost:3000`, execs prodzilla. |
| `fly.preview.toml` | `arn` region, `shared-cpu-1x@256MB`, no `[[services]]` (no public IP), no volume. |
| `.github/workflows/pr-image.yaml` | Owner-only. Builds the prod Dockerfile to `ghcr.io/.../prodzilla:pr-N` and `:sha-X` on every PR push, amd64-only with buildx GHA cache. |
| `.github/workflows/preview.yaml` | Dispatches on `/preview`, `/teardown`, labeled `synchronize`, and PR `closed`. Mints short-lived Tailscale auth keys via OAuth, deletes stale node by hostname for URL stability, runs `fly deploy`, manages a GitHub Deployment + sticky PR comment. Concurrency-grouped per PR. |
| `.github/workflows/preview-image-check.yaml` | CI build-only check when preview-pipeline files change. |

## Manual prerequisites (one-time)

- Create the GitHub Environment **`pr-preview`** with:
  - Variables: `TS_OAUTH_CLIENT_ID`
  - Secrets: `TS_OAUTH_CLIENT_SECRET`, `FLY_API_TOKEN`
- Tailscale tailnet ACL: declare `tag:prodzilla-preview` in `tagOwners` (owner: `autogroup:admin`).
- Tailscale OAuth client with `Devices: Read & Write` scoped to `tag:prodzilla-preview`.
- Tailscale tailnet DNS: HTTPS Certificates enabled.
- GitHub repo: create the `preview` label.

## Test plan

- [ ] Open a no-op PR; verify `pr-image.yaml` pushes `pr-N` and `sha-X` tags to GHCR; no Fly app created.
- [ ] Comment `/preview`; verify `preview` label is applied, GitHub Deployment `preview-pr-N` is created with status `in_progress` → `success`, sticky PR comment posted with HTTPS URL.
- [ ] On a phone with Tailscale connected: open the URL, verify the SPA renders.
- [ ] Push another commit; verify the workflow redeploys, Tailscale node is replaced (no `-1` suffix), sticky comment is edited in place.
- [ ] Comment `/teardown`; verify Fly app destroyed, GHCR `pr-N`/`sha-*` tags deleted, label removed, Deployment marked inactive, sticky comment updated.
- [ ] Close a PR with `preview` label without `/teardown` first; verify teardown runs.
- [ ] Edit `preview.Dockerfile` in a PR; verify `preview-image-check.yaml` builds successfully.
- [ ] Comment `/preview` from a non-owner account; verify the workflow no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)